### PR TITLE
cardinal: improvements all around...

### DIFF
--- a/bin/scout.py
+++ b/bin/scout.py
@@ -900,6 +900,9 @@ if queryCommand == "--disable-radius":
    remote_conn.send("no aaa new-model\n")
    time.sleep(.10)
    output = remote_conn.recv(65535)
+   remote_conn.send("\n")
+   time.sleep(.10)
+   output = remote_conn.recv(65535)
    remote_conn.send("do wr\n")
    time.sleep(.10)
    output = remote_conn.recv(65535)
@@ -911,10 +914,12 @@ if queryCommand == "--disable-snmp":
    queryUser = sys.argv[3]
    queryPass = sys.argv[4]
    querySNMP = sys.argv[5]
+   queryLocation = sys.argv[6]
    ip = queryIP
    username = queryUser
    password = queryPass
    snmp = querySNMP
+   location = queryLocation
    remote_conn_pre = paramiko.SSHClient()
    remote_conn_pre.set_missing_host_key_policy(paramiko.AutoAddPolicy())
    remote_conn_pre.connect(ip, port = 22, username = username,
@@ -932,6 +937,9 @@ if queryCommand == "--disable-snmp":
    time.sleep(.10)
    output = remote_conn.recv(65535)
    remote_conn.send('no snmp-server community %s RW\n' % snmp)
+   time.sleep(.10)
+   output = remote_conn.recv(65535)
+   remote_conn.send('no snmp-server location %s\n' % location)
    time.sleep(.10)
    output = remote_conn.recv(65535)
    remote_conn.send('no snmp-server system-shutdown\n')
@@ -1074,12 +1082,10 @@ if queryCommand == "--tftp-backup":
    queryUser = sys.argv[3]
    queryPass = sys.argv[4]
    queryTFTP = sys.argv[5]
-   queryTFTPName = sys.argv[6]
    ip = queryIP
    username = queryUser
    password = queryPass
    tftp = queryTFTP
-   tftpname = queryTFTPName
    remote_conn_pre = paramiko.SSHClient()
    remote_conn_pre.set_missing_host_key_policy(paramiko.AutoAddPolicy())
    remote_conn_pre.connect(ip, port = 22, username = username,
@@ -1099,7 +1105,7 @@ if queryCommand == "--tftp-backup":
    remote_conn.send('%s\n' % tftp)
    time.sleep(.15)
    output = remote_conn.recv(65535)
-   remote_conn.send('%s\n' % tftpname)
+   remote_conn.send("\n")
    time.sleep(.15)
    output = remote_conn.recv(65535)
 

--- a/dashboard.php
+++ b/dashboard.php
@@ -322,7 +322,7 @@ header('Location: index.php');
 			<div class="col-sm-6 col-md-4">
 				<div class="chart-wrapper">
 					<div class="chart-title">
-						Manage Cardinal Access Point
+						Manage Access Point
 					</div>
 
 
@@ -363,7 +363,7 @@ header('Location: index.php');
                         <div class="col-sm-6 col-md-4">
                                 <div class="chart-wrapper">
                                         <div class="chart-title">
-                                                Manage Cardinal Access Point Group
+                                                Manage Access Point Group
                                         </div>
 
 

--- a/disable_radius.php
+++ b/disable_radius.php
@@ -53,7 +53,7 @@ if ($result->num_rows > 0) {
        $queryIP = $row["ap_ip"];
        $queryUser = $row["ap_ssh_username"];
        $queryPass = $row["ap_ssh_password"];
-       $pyCommand = escapeshellcmd("python $scriptsDir/cisco_disable_radius.py $queryIP $queryUser $queryPass");
+       $pyCommand = escapeshellcmd("scout --disable-radius $queryIP $queryUser $queryPass");
        $pyOutput = shell_exec($pyCommand);
        echo "<font face=\"Verdana\">\n";
        echo "Access Point Disable RADIUS Functionality Initiated!";

--- a/disable_snmp.php
+++ b/disable_snmp.php
@@ -44,7 +44,7 @@ require_once('includes/cardinalconfig.php');
 
 $varAPId = $_SESSION['apid'];
 
-$sql = "SELECT ap_ip,ap_ssh_username,ap_ssh_password,ap_snmp FROM access_points WHERE ap_id = $varAPId";
+$sql = "SELECT ap_ip,ap_ssh_username,ap_ssh_password,ap_snmp,ap_location FROM access_points WHERE ap_id = $varAPId";
 $result = $conn->query($sql);
 
 if ($result->num_rows > 0) {
@@ -54,7 +54,8 @@ if ($result->num_rows > 0) {
        $queryUser = $row["ap_ssh_username"];
        $queryPass = $row["ap_ssh_password"];
        $querySNMP = $row["ap_snmp"];
-       $pyCommand = escapeshellcmd("python $scriptsDir/cisco_disable_snmp.py $queryIP $queryUser $queryPass $querySNMP");
+       $queryLocation = $row["ap_location"];
+       $pyCommand = escapeshellcmd("scout --disable-snmp $queryIP $queryUser $queryPass $querySNMP $queryLocation");
        $pyOutput = shell_exec($pyCommand);
        echo "<font face=\"Verdana\">\n";
        echo "Access Point Disable SNMP Functionality Initiated!";

--- a/manage_ap_dashboard.php
+++ b/manage_ap_dashboard.php
@@ -77,33 +77,8 @@ $_SESSION['apid'] = $varAPId;
 			<div class="navbar-header">
 				<button class="navbar-toggle" data-target=".navbar-collapse" data-toggle="collapse" type="button"><span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span></button> <a class="navbar-brand" href="./dashboard.php">Cardinal</a>
 			</div>
-
-
-			<div class="navbar-collapse collapse">
-				<ul class="nav navbar-nav navbar-left">
-					<li>
-						<a href="./">Home</a>
-					</li>
-
-
-					<li>
-						<a href="http://cardinal.mcclunetechnologies.net">Developer</a>
-					</li>
-
-
-					<li>
-						<a href="https://github.com/falcon78921">Source</a>
-					</li>
-
-
-					<li>
-						<a href="https://github.com/falcon78921">Technical Support</a>
-					</li>
-				</ul>
-			</div>
 		</div>
 	</div>
-
 
 	<div class="container-fluid">
 		<div class="row">
@@ -329,6 +304,47 @@ $_SESSION['apid'] = $varAPId;
 
                                         <div class="chart-notes">
                                                 Configure SNMP on A Single Access Point
+                                        </div>
+                                </div>
+                        </div>
+
+                                <div class="col-sm-6 col-md-4">
+                                <div class="chart-wrapper">
+                                        <div class="chart-title">
+                                                Deploy SSID
+                                        </div>
+
+
+                                        <div class="chart-stage">
+                                                <center>
+                                                        <a class="deploy_ssid" href="deploy_ssid_wizard.php"><img src="assets/img/cardinal5.png"></a>
+                                                </center>
+                                        </div>
+
+
+                                        <div id="deployssid" style="display:none;" title="Deploy SSID">
+                                                <iframe height="350" id="deploy_ssid_frame" name="deploy_ssid_frame" width="350"></iframe>
+                                        </div>
+                                        <script>
+                                        $(document).ready(function () {
+                                        $(".deploy_ssid").click(function () {
+                                           $("#deploy_ssid_frame").attr('src', $(this).attr("href"));
+                                           $("#deployssid").dialog({
+                                               width: 400,
+                                               height: 450,
+                                               modal: true,
+                                               close: function () {
+                                                   $("#deploy_ssid_frame").attr('src', "about:blank");
+                                               }
+                                           });
+                                           return false;
+                                        });
+                                        });
+
+                                        </script>
+
+                                        <div class="chart-notes">
+                                                Deploy SSID to Access Point
                                         </div>
                                 </div>
                         </div>

--- a/manage_ap_group_dashboard.php
+++ b/manage_ap_group_dashboard.php
@@ -74,29 +74,6 @@ $_SESSION['groupid'] = $varGroupId;
 			<div class="navbar-header">
 				<button class="navbar-toggle" data-target=".navbar-collapse" data-toggle="collapse" type="button"><span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span></button> <a class="navbar-brand" href="./dashboard.php">Cardinal</a>
 			</div>
-
-
-			<div class="navbar-collapse collapse">
-				<ul class="nav navbar-nav navbar-left">
-					<li>
-						<a href="./">Home</a>
-					</li>
-
-
-					<li>
-						<a href="http://cardinal.mcclunetechnologies.net">Developer</a>
-					</li>
-
-
-					<li>
-						<a href="https://github.com/falcon78921">Source</a>
-					</li>
-
-
-					<li>
-						<a href="https://github.com/falcon78921">Technical Support</a>
-					</li>
-				</ul>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
scout: added location for --disable-snmp
When disabling SNMP, scout will also pass location for removal.

dashboard: removed redundant Cardinal name in tiles
Removed Cardinal from Manage Access Point and Manage Access Point
Group.

radius: added scout for disable_radius.php

snmp: added scout for disable_snmp.php

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>