### PR TITLE
Cardinal: Changed license headers to reflect Cardinal Contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 James McClune
+Copyright (c) 2017 Cardinal Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <h1>Cardinal</h1>
 
-Cardinal is an open source Cisco access point controller. Cardinal is built on the LAMP stack, and uses Python to handle the configuration of access points via SSH. In order to use Cardinal, your Cisco AP's must be in autonomous mode (K9W7 IOS) and have SSH enabled. 
+Cardinal is an open source Cisco access point controller. Cardinal is built on Python and uses `paramiko` to handle the configuration of access points via SSH. In order to use Cardinal, your Cisco AP's must be in autonomous mode (K9W7 IOS) and have SSH enabled. 
 
 <h2>Why Cardinal?</h2>
 Cardinals are beautiful, majestic birds. People say that Cardinals represent loved ones who have passed. When Cardinals visit you, they carry love and remembrance. When I developed Cardinal, I thought of one person, in particular, who loved the red birds. I would go visit a woman in a nursing home, who loved Cardinals. This woman was exceptionally benevolent and a beautiful soul. Her humor and smile lit up the room every time I would visit. Even though I didn’t know her for a long time, knowing her for the length I did was a privilege. Unfortunately, she passed away in 2013.

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@
 
 MIT License
 
-Copyright © 2019 falcon78921
+Copyright © 2019 Cardinal Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,7 +4,7 @@
 
 # MIT License
 
-# Copyright © 2019 falcon78921
+# Copyright © 2019 Cardinal Contributors
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -4,7 +4,7 @@
 
 # MIT License
 
-# Copyright © 2019 falcon78921
+# Copyright © 2019 Cardinal Contributors
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/scout.py
+++ b/bin/scout.py
@@ -4,7 +4,7 @@
 
 MIT License
 
-Copyright © 2019 falcon78921
+Copyright © 2019 Cardinal Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Now that Cardinal has contributions from someone other than me,
the license headers should reflect that.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>