### PR TITLE
bin/scout: fixed command templates for scout_ssid ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/scout/__pycache__
 bin/scout-cli/__pycache__
 webapp/__pycache__
 webapp/cardinal/views/__pycache__
+ci/tests/scout-tests.sh

--- a/bin/scout-cli/scout-cli.py
+++ b/bin/scout-cli/scout-cli.py
@@ -219,18 +219,16 @@ if len(sys.argv) > 1:
         ip, username, password = scoutArgs()
         ssid = sys.argv[5]
         vlan = sys.argv[6]
-        bridgeGroup = sys.argv[7]
-        radioSub = sys.argv[8]
-        gigaSub = sys.argv[9]
-        scout_ssid.scoutDeleteSsid24(ip=ip, username=username, password=password, ssid=ssid, vlan=vlan, bridgeGroup=bridgeGroup, radioSub=radioSub, gigaSub=gigaSub)
+        radioSub = sys.argv[7]
+        gigaSub = sys.argv[8]
+        scout_ssid.scoutDeleteSsid24(ip=ip, username=username, password=password, ssid=ssid, vlan=vlan, radioSub=radioSub, gigaSub=gigaSub)
     elif (scoutCommand == "--delete-ssid-5") or (scoutCommand == "--delete-ssid-radius-5"):
         ip, username, password = scoutArgs()
         ssid = sys.argv[5]
         vlan = sys.argv[6]
-        bridgeGroup = sys.argv[7]
-        radioSub = sys.argv[8]
-        gigaSub = sys.argv[9]
-        scout_ssid.scoutDeleteSsid5(ip=ip, username=username, password=password, ssid=ssid, vlan=vlan, bridgeGroup=bridgeGroup, radioSub=radioSub, gigaSub=gigaSub)
+        radioSub = sys.argv[7]
+        gigaSub = sys.argv[8]
+        scout_ssid.scoutDeleteSsid5(ip=ip, username=username, password=password, ssid=ssid, vlan=vlan, radioSub=radioSub, gigaSub=gigaSub)
 
 else:
     print("ERROR: No valid options detected. Please use --help for a list of valid options.")

--- a/bin/scout-cli/scout_auth.py
+++ b/bin/scout-cli/scout_auth.py
@@ -1,1 +1,1 @@
-/opt/Cardinal/bin/scout/scout_auth.py
+../scout/scout_auth.py

--- a/bin/scout-cli/scout_env.py
+++ b/bin/scout-cli/scout_env.py
@@ -1,1 +1,1 @@
-/opt/Cardinal/bin/scout/scout_env.py
+../scout/scout_env.py

--- a/bin/scout-cli/scout_info.py
+++ b/bin/scout-cli/scout_info.py
@@ -1,1 +1,1 @@
-/opt/Cardinal/bin/scout/scout_info.py
+../scout/scout_info.py

--- a/bin/scout-cli/scout_ssid.py
+++ b/bin/scout-cli/scout_ssid.py
@@ -1,1 +1,1 @@
-/opt/Cardinal/bin/scout/scout_ssid.py
+../scout/scout_ssid.py

--- a/bin/scout-cli/scout_sys.py
+++ b/bin/scout-cli/scout_sys.py
@@ -1,1 +1,1 @@
-/opt/Cardinal/bin/scout/scout_sys.py
+../scout/scout_sys.py

--- a/bin/scout/scout_env.py
+++ b/bin/scout/scout_env.py
@@ -36,6 +36,13 @@ def scoutEnv():
     cardinalConfigFile = os.environ['CARDINALCONFIG']
     cardinalConfig = ConfigParser()
     cardinalConfig.read("{}".format(cardinalConfigFile))
+    commandDebug = cardinalConfig.get('cardinal', 'commanddebug')
+    return commandDebug
+
+def scoutJinjaEnv():
+    cardinalConfigFile = os.environ['CARDINALCONFIG']
+    cardinalConfig = ConfigParser()
+    cardinalConfig.read("{}".format(cardinalConfigFile))
     commandDir = cardinalConfig.get('cardinal', 'commanddir')
     fileLoader = jinja2.FileSystemLoader('{}'.format(commandDir))
     env = jinja2.Environment(loader=fileLoader)

--- a/bin/scout/scout_info.py
+++ b/bin/scout/scout_info.py
@@ -92,8 +92,8 @@ def scoutGetModel(ip, username, password):
 def scoutGetHostname(ip, username, password):
     """Function that retrieves AP hostname via show version."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_get_hostname")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_get_hostname")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
@@ -107,8 +107,8 @@ def scoutGetHostname(ip, username, password):
 def scoutGetLocation(ip, username, password):
     """Function that retrieves AP location via show snmp location."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_get_location")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_get_location")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
@@ -124,8 +124,8 @@ def scoutGetLocation(ip, username, password):
 def scoutGetUsers(ip, username, password):
     """Function that retrieves AP users via show users."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_get_users")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_get_users")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()

--- a/bin/scout/scout_ssid.py
+++ b/bin/scout/scout_ssid.py
@@ -37,20 +37,24 @@ def scoutCreateSsid24(ip, username, password, ssid, wpa2Pass, vlan, bridgeGroup,
     using user provided arguments.
     """
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     ssid = ssid
     wpa2Pass = wpa2Pass
     vlan = vlan
     bridgeGroup = bridgeGroup
     radioSub = radioSub
     gigaSub = gigaSub
-    cmdTemplate = env.get_template("scout_create_ssid_24")
+    cmdTemplate = jinjaEnv.get_template("scout_create_ssid_24")
     cmds = cmdTemplate.render(password=password,ssid=ssid,wpa2Pass=wpa2Pass,vlan=vlan,bridgeGroup=bridgeGroup,radioSub=radioSub,gigaSub=gigaSub)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Deploying 2.4GHz SSID {0} to {1}...".format(ssid,ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
@@ -58,21 +62,25 @@ def scoutCreateSsid5(ip, username, password, ssid, wpa2Pass, vlan, bridgeGroup, 
     """Function that deploys a 5GHz SSID to an AP
     using user provided arguments.
     """
-    ip, username, password, scoutSsh = scout_auth.sshInfo()
-    env = scout_env.scoutEnv()
+    scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     ssid = ssid
     wpa2Pass = wpa2Pass
     vlan = vlan
     bridgeGroup = bridgeGroup
     radioSub = radioSub
     gigaSub = gigaSub
-    cmdTemplate = env.get_template("scout_create_ssid_5")
+    cmdTemplate = jinjaEnv.get_template("scout_create_ssid_5")
     cmds = cmdTemplate.render(password=password,ssid=ssid,wpa2Pass=wpa2Pass,vlan=vlan,bridgeGroup=bridgeGroup,radioSub=radioSub,gigaSub=gigaSub)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Deploying 5GHz SSID {0} to {1}...".format(ssid,ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
@@ -81,7 +89,8 @@ def scoutCreateSsid24Radius(ip, username, password, ssid, vlan, bridgeGroup, rad
     AP using user provided arguments.
     """
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     ssid = ssid
     vlan = vlan
     bridgeGroup = bridgeGroup
@@ -94,13 +103,16 @@ def scoutCreateSsid24Radius(ip, username, password, ssid, vlan, bridgeGroup, rad
     radiusTimeout = radiusTimeout
     radiusGroup = radiusGroup
     methodList = methodList
-    cmdTemplate = env.get_template("scout_create_radius_ssid_24")
+    cmdTemplate = jinjaEnv.get_template("scout_create_radius_ssid_24")
     cmds = cmdTemplate.render(password=password,ssid=ssid,vlan=vlan,bridgeGroup=bridgeGroup,radioSub=radioSub,gigaSub=gigaSub,radiusIp=radiusIp,sharedSecret=sharedSecret,authPort=authPort,acctPort=acctPort,radiusTimeout=radiusTimeout,radiusGroup=radiusGroup,methodList=methodList)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Deploying 2.4GHz RADIUS SSID {0} to {1}...".format(ssid,ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
@@ -109,7 +121,8 @@ def scoutCreateSsid5Radius(ip, username, password, ssid, vlan, bridgeGroup, radi
     AP using user provided arguments.
     """
     scoutSsh = scout_auth.sshInfo(ip=ip,username=username,password=password)
-    env = scout_env.scoutEnv()
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     ssid = ssid
     vlan = vlan
     bridgeGroup = bridgeGroup
@@ -122,34 +135,40 @@ def scoutCreateSsid5Radius(ip, username, password, ssid, vlan, bridgeGroup, radi
     radiusTimeout = radiusTimeout
     radiusGroup = radiusGroup
     methodList = methodList
-    cmdTemplate = env.get_template("scout_create_radius_ssid_5")
+    cmdTemplate = jinjaEnv.get_template("scout_create_radius_ssid_5")
     cmds = cmdTemplate.render(password=password,ssid=ssid,vlan=vlan,bridgeGroup=bridgeGroup,radioSub=radioSub,gigaSub=gigaSub,radiusIp=radiusIp,sharedSecret=sharedSecret,authPort=authPort,acctPort=acctPort,radiusTimeout=radiusTimeout,radiusGroup=radiusGroup,methodList=methodList)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Deploying 5GHz RADIUS SSID {0} to {1}...".format(ssid,ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
-def scoutDeleteSsid24(ip, username, password, ssid, vlan, bridgeGroup, radioSub, gigaSub):
+def scoutDeleteSsid24(ip, username, password, ssid, vlan, radioSub, gigaSub):
     """Function that deletes an existing 2.4GHz SSID from
     an AP.
     """
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     ssid = ssid
     vlan = vlan
-    bridgeGroup = bridgeGroup
     radioSub = radioSub
     gigaSub = gigaSub
-    cmdTemplate = env.get_template("scout_delete_ssid_24")
+    cmdTemplate = jinjaEnv.get_template("scout_delete_ssid_24")
     cmds = cmdTemplate.render(password=password,ssid=ssid,vlan=vlan,radioSub=radioSub,gigaSub=gigaSub)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Removing 2.4GHz SSID {0} from {1}...".format(ssid,ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
@@ -158,18 +177,22 @@ def scoutDeleteSsid5(ip, username, password, ssid, vlan, bridgeGroup, radioSub, 
     AP.
     """
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     ssid = ssid
     vlan = vlan
     bridgeGroup = bridgeGroup
     radioSub = radioSub
     gigaSub = gigaSub
-    cmdTemplate = env.get_template("scout_delete_ssid_5")
+    cmdTemplate = jinjaEnv.get_template("scout_delete_ssid_5")
     cmds = cmdTemplate.render(password=password,ssid=ssid,vlan=vlan,radioSub=radioSub,gigaSub=gigaSub)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Removing 5GHz SSID {0} from {1}...".format(ssid,ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()

--- a/bin/scout/scout_sys.py
+++ b/bin/scout/scout_sys.py
@@ -49,16 +49,20 @@ def scoutChangeIp(ip, username, password, newIp, subnetMask):
     change.
     """
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     newIp = newIp
     subnetMask = subnetMask
-    cmdTemplate = env.get_template("scout_change_ap_ip")
+    cmdTemplate = jinjaEnv.get_template("scout_change_ap_ip")
     cmds = cmdTemplate.render(password=password,newIp=newIp,subnetMask=subnetMask)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Changing IP from {0} to {1}...".format(ip,newIp))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
     scoutDoWr(ip=newIp, username=username, password=password)
@@ -66,156 +70,200 @@ def scoutChangeIp(ip, username, password, newIp, subnetMask):
 def scoutDisableHttp(ip, username, password):
     """Function that disables the HTTP server on AP."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_disable_ap_http")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_disable_ap_http")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Disabling HTTP server on {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutDisableRadius(ip, username, password):
     """Function that disables RADIUS on AP."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_disable_ap_radius")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_disable_ap_radius")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Disabling RADIUS on {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutDisableSnmp(ip, username, password):
     """Function that disables SNMP on AP."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_disable_ap_snmp")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_disable_ap_snmp")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Disabling SNMP server on {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutEnableHttp(ip, username, password):
     """Function that enables the HTTP server on AP."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_enable_ap_http")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_enable_ap_http")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Enabling HTTP server on {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutEnableRadius(ip, username, password):
     """Function that enables RADIUS on AP."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_enable_ap_radius")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_enable_ap_radius")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Enabling RADIUS on {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutEnableSnmp(ip, username, password, snmp):
     """Function that enables SNMP on AP."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     snmp = snmp
-    cmdTemplate = env.get_template("scout_enable_ap_snmp")
+    cmdTemplate = jinjaEnv.get_template("scout_enable_ap_snmp")
     cmds = cmdTemplate.render(password=password,snmp=snmp)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Enabling SNMP server on {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutTftpBackup(ip, username, password, tftpIp):
     """Function that performs TFTP backup of AP config."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     tftpIp = tftpIp
-    cmdTemplate = env.get_template("scout_do_tftp_backup")
+    cmdTemplate = jinjaEnv.get_template("scout_do_tftp_backup")
     cmds = cmdTemplate.render(password=password,tftpIp=tftpIp)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Generating TFTP backup for {0} and sending to {1}...".format(ip,tftpIp))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutDoWr(ip, username, password):
     """Function that performs write command on AP."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_do_wr")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_do_wr")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Committing changes on {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutWriteDefault(ip, username, password):
     """Function that wipes AP memory back to default."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_write_default")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_write_default")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Erasing config on {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutChangeName(ip, username, password, apName):
     """Function that changes the hostname of AP."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
     apName = apName
-    cmdTemplate = env.get_template("scout_change_ap_name")
+    cmdTemplate = jinjaEnv.get_template("scout_change_ap_name")
     cmds = cmdTemplate.render(apName=apName,password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Changing AP hostname on {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()
 
 def scoutDoReboot(ip, username, password):
     """Function that reboots AP."""
     scoutSsh = scout_auth.sshInfo(ip=ip, username=username, password=password)
-    env = scout_env.scoutEnv()
-    cmdTemplate = env.get_template("scout_reboot_ap")
+    jinjaEnv = scout_env.scoutJinjaEnv()
+    commandDebug = scout_env.scoutEnv()
+    cmdTemplate = jinjaEnv.get_template("scout_reboot_ap")
     cmds = cmdTemplate.render(password=password)
     scoutCommands = cmds.splitlines()
     channel = scoutSsh.invoke_shell()
     print("INFO: Rebooting {}...".format(ip))
     for command in scoutCommands:
         channel.send('{}\n'.format(command))
+        if commandDebug == "on":
+            commands = channel.recv(65535)
+            print(commands)
         time.sleep(.10)
     scoutSsh.close()

--- a/bin/scout/templates/scout_create_ssid_24
+++ b/bin/scout/templates/scout_create_ssid_24
@@ -7,14 +7,14 @@ mbssid guest-mode
 auth key-man wpa version 2
 wpa-psk ascii {{ wpa2Pass }}
 vlan {{ vlan }}
-int d0
+int Dot11Radio0
 mbssid
 encryption vlan {{ vlan }} mode ciphers aes
 no shutdown
 dot11 ssid {{ ssid }}
-int d0
+int Dot11Radio0
 ssid {{ ssid }}
-int d0.{{ radioSub }}
+int Dot11Radio0.{{ radioSub }}
 encapsulation dot1q {{ vlan }}
 bridge-group {{ bridgeGroup }}
 int gi0.{{ gigaSub }}

--- a/bin/scout/templates/scout_create_ssid_5
+++ b/bin/scout/templates/scout_create_ssid_5
@@ -7,14 +7,14 @@ mbssid guest-mode
 auth key-man wpa version 2
 wpa-psk ascii {{ wpa2Pass }}
 vlan {{ vlan }}
-int d1
+int Dot11Radio1
 mbssid
 encryption vlan {{ vlan }} mode ciphers aes
 no shutdown
 dot11 ssid {{ ssid }}
-int d1
+int Dot11Radio1
 ssid {{ ssid }}
-int d1.{{ radioSub }}
+int Dot11Radio1.{{ radioSub }}
 encapsulation dot1q {{ vlan }}
 bridge-group {{ bridgeGroup }}
 int gi0.{{ gigaSub }}

--- a/bin/scout/templates/scout_delete_ssid_24
+++ b/bin/scout/templates/scout_delete_ssid_24
@@ -2,8 +2,8 @@ enable
 {{ password }}
 conf t
 no dot11 ssid {{ ssid }}
-no int d0.{{ radioSub }}
+no int Dot11Radio0.{{ radioSub }}
 no int gi0.{{ gigaSub }}
-int d0
+int Dot11Radio0
 no encryption vlan {{ vlan }} mode ciphers aes-ccm
 do wr

--- a/bin/scout/templates/scout_delete_ssid_5
+++ b/bin/scout/templates/scout_delete_ssid_5
@@ -2,8 +2,8 @@ enable
 {{ password }}
 conf t
 no dot11 ssid {{ ssid }}
-no int d0.{{ radioSub }}
+no int Dot11Radio1.{{ radioSub }}
 no int gi0.{{ gigaSub }}
-int d0
+int Dot11Radio1
 no encryption vlan {{ vlan }} mode ciphers aes-ccm
 do wr

--- a/ci/cardinal.ini
+++ b/ci/cardinal.ini
@@ -7,3 +7,4 @@ commanddir=../bin/commands
 logfile=/var/log/cardinal/cardinal.log
 flaskkey=bad9425ff652b1bd52b49720abecf0ba
 encryptkey=_c5N1Ge4vQpMhnWORDaxTVwOw23xMNZTWG-8iDeoPYo=
+commanddebug=off


### PR DESCRIPTION
Added updated commands for scout_ssid templates. Newer Cisco
Aironet APs no longer accept d0 as an alias for the Dot11Radio
interface.

Started the groundwork for a test suite. Testing against older
Aironet 1142 series APs that may still be in use as well as the newer
2900/3700 series.

Added commanddebug as a mandatory option to specify, however,
it's not required to be on. commanddebug will allow users
to see each command being executed on the AP.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>