### PR TITLE
scout: added returns to scout functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ webapp/cardinal/__pycache__
 webapp/cardinal/system/__pycache__
 webapp/cardinal/views/__pycache__
 ci/tests/scout-tests.sh
+lib/scout/__pycache__

--- a/bin/scout-cli/scout-cli.py
+++ b/bin/scout-cli/scout-cli.py
@@ -85,37 +85,47 @@ if len(sys.argv) > 1:
         scoutUsage()
     elif scoutCommand == "--get-arp":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetArp(ip=ip, username=username, password=password)
+        getArp = scout_info.scoutGetArp(ip=ip, username=username, password=password)
+        print(getArp)
     elif scoutCommand == "--get-speed":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetSpeed(ip=ip, username=username, password=password)
+        getSpeed = scout_info.scoutGetSpeed(ip=ip, username=username, password=password)
+        print(getSpeed + 'Mbps')
     elif scoutCommand == "--count-clients":
         ip, username, password = scoutArgs()
         scout_info.scoutCountClients(ip=ip, username=username, password=password)
     elif scoutCommand == "--get-mac":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetMac(ip=ip, username=username, password=password)
+        getMacAddr = scout_info.scoutGetMac(ip=ip, username=username, password=password)
+        print(getMacAddr)
     elif scoutCommand == "--get-model":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetModel(ip=ip, username=username, password=password)
+        getApModel = scout_info.scoutGetModel(ip=ip, username=username, password=password)
+        print(getApModel)
     elif scoutCommand == "--get-name":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetHostname(ip=ip, username=username, password=password)
+        getApName = scout_info.scoutGetHostname(ip=ip, username=username, password=password)
+        print(getApName)
     elif scoutCommand == "--get-serial":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetSerial(ip=ip, username=username, password=password)
+        getApSerial = scout_info.scoutGetSerial(ip=ip, username=username, password=password)
+        print(getApSerial)
     elif scoutCommand == "--get-ios-info":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetIosInfo(ip=ip, username=username, password=password)
+        getApIosInfo = scout_info.scoutGetIosInfo(ip=ip, username=username, password=password)
+        print(getApIosInfo)
     elif scoutCommand == "--get-location":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetLocation(ip=ip, username=username, password=password)
+        getApLocation = scout_info.scoutGetLocation(ip=ip, username=username, password=password)
+        print(getApLocation)
     elif scoutCommand == "--get-uptime":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetUptime(ip=ip, username=username, password=password)
+        getApUptime = scout_info.scoutGetUptime(ip=ip, username=username, password=password)
+        print(getApUptime)
     elif scoutCommand == "--get-users":
         ip, username, password = scoutArgs()
-        scout_info.scoutGetUsers(ip=ip, username=username, password=password)
+        getApUsers = scout_info.scoutGetUsers(ip=ip, username=username, password=password)
+        print(getApUsers)
 
     # SCOUT SYS COMMANDS
     if scoutCommand == "--led":

--- a/ci/tests/travis-test.sh
+++ b/ci/tests/travis-test.sh
@@ -31,7 +31,7 @@ pythonTests() {
     flake8 bin/setup.py --count --select=E9,F63,F72,F82 --show-source --statistics
     flake8 ci/tests/*.py --count --select=E9,F63,F72,F82 --show-source --statistics
     flake8 webapp/wsgi.py --count --select=E9,F63,F72,F82 --show-source --statistics
-    flake8 webapp/cardinal/system/cardinal_sys.py --count --select=E9,F63,F72,F82 --show-source --statistics
+    flake8 webapp/cardinal/system/*.py --count --select=E9,F63,F72,F82 --show-source --statistics
     flake8 webapp/cardinal/views/*.py --count --select=E9,F63,F72,F82 --show-source --statistics
 }
 

--- a/conf/cardinal.ini.sample
+++ b/conf/cardinal.ini.sample
@@ -4,7 +4,7 @@ dbuser=dbuser
 dbpassword=password
 dbname=cardinal
 commanddir=/home/Cardinal/bin/scout/templates
-logfile=/var/log/cardinal/cardinal.log
+fetchinterval=3
 flaskkey=d67ff999decd7439c230f519ea9fb999
 encryptkey=rFLoNiCTwoOa6o8QOXBy-9WK2-IdSTT8HKiiIzQFHVVZ=
 commanddebug=off

--- a/lib/scout/scout_info.py
+++ b/lib/scout/scout_info.py
@@ -43,7 +43,7 @@ def scoutGetArp(ip, username, password):
     sshOut = stdout.read()
     getArpTable = sshOut.decode('ascii').strip("\n").lstrip()
     scoutSsh.close()
-    print(getArpTable)
+    return getArpTable
 
 def scoutGetSpeed(ip, username, password):
     """Function that reports speed of Gi0/0 in Mbps."""
@@ -53,7 +53,7 @@ def scoutGetSpeed(ip, username, password):
     sshBandwidth = sshOut.decode('ascii').strip("\n").split(",")
     getBandwidth = sshBandwidth[9].strip("Mbps")
     scoutSsh.close()
-    print(getBandwidth + "Mbps")
+    return getBandwidth
 
 def scoutGetMac(ip, username, password):
     """Function that reports back the MAC address of AP."""
@@ -64,7 +64,7 @@ def scoutGetMac(ip, username, password):
     intList = sshOut.decode('ascii').strip("\n").split(",")
     getMac = macAddrRegex.search(intList[2]).group(0)
     scoutSsh.close()
-    print(getMac)
+    return getMac
 
 def scoutCountClients(ip, username, password):
     """Function that reports the number of active clients on
@@ -76,7 +76,7 @@ def scoutCountClients(ip, username, password):
     countClient = sshOut.decode('ascii').strip("\n")
     getClient = subprocess.check_output("echo {} | grep -o [0-9,a-f][0-9,a-f][0-9,a-f][0-9,a-f].[0-9,a-f][0-9,a-f][0-9,a-f][0-9,a-f].[0-9,a-f][0-9,a-f][0-9,a-f][0-9,a-f] | wc -l".format(countClient), shell=True)
     scoutSsh.close()
-    print(getClient.decode('ascii').strip("\n").lstrip())
+    return getClient.decode('ascii').strip("\n").lstrip()
 
 def scoutGetModel(ip, username, password):
     """Function that reports the model ID of AP."""
@@ -87,7 +87,7 @@ def scoutGetModel(ip, username, password):
     apModelRegex = re.compile(r'\w\w\w\-\w\w\w\w\w\w\w\w\-\w-\w\w')
     getApModel = apModelRegex.search(getModelString).group(0)
     scoutSsh.close()
-    print(getApModel)
+    return getApModel
 
 def scoutGetHostname(ip, username, password):
     """Function that retrieves AP hostname via show version."""
@@ -102,7 +102,7 @@ def scoutGetHostname(ip, username, password):
         time.sleep(.10)
     getHostname = channel.recv(65535).decode('ascii').strip("\n").strip(">").lstrip()
     scoutSsh.close()
-    print(getHostname)
+    return getHostname
 
 def scoutGetLocation(ip, username, password):
     """Function that retrieves AP location via show snmp location."""
@@ -118,8 +118,8 @@ def scoutGetLocation(ip, username, password):
     if channel.recv_ready():
         sshReturn = channel.recv(65535)
         location = sshReturn.decode('ascii').splitlines()
-        print(location[4])
     scoutSsh.close()
+    return location[4]
 
 def scoutGetUsers(ip, username, password):
     """Function that retrieves AP users via show users."""
@@ -134,10 +134,12 @@ def scoutGetUsers(ip, username, password):
         time.sleep(.10)
     if channel.recv_ready():
         sshReturn = channel.recv(65535)
-        users = sshReturn.splitlines()
-        for line in users[4:-1]:
-            print(line.decode('ascii').strip("\n"))
-    scoutSsh.close()
+        userLines = sshReturn.splitlines()
+        scoutSsh.close()
+        getUsers = []
+        for line in userLines[4:-1]:
+            getUsers.append(line.decode('ascii').strip("\n"))
+    return "\n".join(getUsers)
 
 def scoutGetSerial(ip, username, password):
     """Function that reports the serial number of AP."""
@@ -148,7 +150,7 @@ def scoutGetSerial(ip, username, password):
     apSerialRegex = re.compile(r'\w\w\w\w\w\w\w\w\w\w\w')
     getApSerial = apSerialRegex.search(getSerialString).group(0)
     scoutSsh.close()
-    print(getApSerial)
+    return getApSerial
 
 def scoutGetIosInfo(ip, username, password):
     """Function that retrieves AP IOS info via show version."""
@@ -157,7 +159,7 @@ def scoutGetIosInfo(ip, username, password):
     sshOut = stdout.read().splitlines()
     getIosInfo = sshOut[0].decode('ascii').strip("\n")
     scoutSsh.close()
-    print(getIosInfo)
+    return getIosInfo
 
 def scoutGetUptime(ip, username, password):
     """Function that retrieves AP uptime via show version."""
@@ -166,4 +168,4 @@ def scoutGetUptime(ip, username, password):
     sshOut = stdout.read().splitlines()
     getApUptime = sshOut[8].decode('ascii').strip("\n")
     scoutSsh.close()
-    print(getApUptime)
+    return getApUptime

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# IMPORTANT: scout is required and must be packaged from bin/
+# IMPORTANT: scout is required and must be packaged from lib/
 
 pyinstaller
 flake8
@@ -33,3 +33,4 @@ werkzeug
 flask
 jinja2
 uwsgi
+schedule

--- a/sql/cardinal.sql
+++ b/sql/cardinal.sql
@@ -24,10 +24,10 @@ DROP TABLE IF EXISTS `access_point_groups`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `access_point_groups` (
   `ap_group_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ap_group_name` text NOT NULL,
+  `ap_group_name` text CHARACTER SET utf8 NOT NULL,
   PRIMARY KEY (`ap_group_id`),
   UNIQUE KEY `access_point_groups` (`ap_group_name`(255))
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=latin1 COMMENT='For Cardinal Access Point Groups';
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=latin1 COMMENT='For Cardinal Access Point Groups';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -39,26 +39,25 @@ DROP TABLE IF EXISTS `access_points`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `access_points` (
   `ap_id` int(11) NOT NULL AUTO_INCREMENT,
-  `ap_group_id` varchar(11) DEFAULT NULL,
-  `ap_name` text NOT NULL,
-  `ap_ip` text NOT NULL,
-  `ap_ssh_username` text NOT NULL,
-  `ap_ssh_password` text NOT NULL,
-  `ap_snmp` text NOT NULL,
-  `ap_total_clients` varchar(255) DEFAULT '0',
-  `ap_bandwidth` varchar(255) DEFAULT NULL,
-  `ap_mac_addr` varchar(255) DEFAULT NULL,
-  `ap_model` varchar(255) DEFAULT NULL,
-  `ap_serial` varchar(255) DEFAULT NULL,
-  `ap_location` varchar(255) DEFAULT NULL,
-  `ap_ios_info` varchar(255) DEFAULT NULL,
-  `ap_ping_ms` varchar(255) DEFAULT NULL,
-  `ap_uptime` varchar(255) DEFAULT NULL,
+  `ap_group_id` varchar(11) CHARACTER SET utf8 DEFAULT NULL,
+  `ap_name` text CHARACTER SET utf8,
+  `ap_ip` text CHARACTER SET utf8 NOT NULL,
+  `ap_ssh_username` text CHARACTER SET utf8 NOT NULL,
+  `ap_ssh_password` text CHARACTER SET utf8 NOT NULL,
+  `ap_snmp` text CHARACTER SET utf8 NOT NULL,
+  `ap_total_clients` varchar(255) CHARACTER SET utf8 DEFAULT '0',
+  `ap_bandwidth` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `ap_mac_addr` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `ap_model` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `ap_serial` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `ap_location` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `ap_ios_info` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `ap_uptime` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `ap_all_id` int(11) DEFAULT '2',
   PRIMARY KEY (`ap_id`),
-  UNIQUE KEY `ap_name` (`ap_name`(255)),
-  UNIQUE KEY `ap_ip` (`ap_ip`(15))
-) ENGINE=InnoDB AUTO_INCREMENT=37 DEFAULT CHARSET=latin1 COMMENT='For Cardinal Individual Access Points';
+  UNIQUE KEY `ap_ip` (`ap_ip`(15)),
+  UNIQUE KEY `ap_name` (`ap_name`(255))
+) ENGINE=InnoDB AUTO_INCREMENT=40 DEFAULT CHARSET=latin1 COMMENT='For Cardinal Individual Access Points';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -78,7 +77,7 @@ CREATE TABLE `ssids_24ghz` (
   `ap_ssid_ethernet_id` int(11) NOT NULL,
   PRIMARY KEY (`ap_ssid_id`),
   UNIQUE KEY `ap_ssid_name` (`ap_ssid_name`(255))
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1 COMMENT='For Cardinal SSIDs on 2.4GHz radio';
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=latin1 COMMENT='For Cardinal SSIDs on 2.4GHz radio';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -97,7 +96,7 @@ CREATE TABLE `ssids_24ghz_deployed` (
   KEY `ssid_id` (`ssid_id`),
   CONSTRAINT `ssids_24ghz_deployed_ibfk_1` FOREIGN KEY (`ssid_id`) REFERENCES `ssids_24ghz` (`ap_ssid_id`),
   CONSTRAINT `ssids_24ghz_deployed_ibfk_2` FOREIGN KEY (`ap_id`) REFERENCES `access_points` (`ap_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -142,7 +141,7 @@ CREATE TABLE `ssids_24ghz_radius_deployed` (
   KEY `ssid_id` (`ssid_id`),
   CONSTRAINT `ssids_24ghz_radius_deployed_ibfk_1` FOREIGN KEY (`ssid_id`) REFERENCES `ssids_24ghz_radius` (`ap_ssid_id`),
   CONSTRAINT `ssids_24ghz_radius_deployed_ibfk_2` FOREIGN KEY (`ap_id`) REFERENCES `access_points` (`ap_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -207,7 +206,7 @@ CREATE TABLE `ssids_5ghz_radius` (
   `ap_ssid_radius_method_list` text,
   PRIMARY KEY (`ap_ssid_id`),
   UNIQUE KEY `ap_ssid_name` (`ap_ssid_name`(255))
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 COMMENT='For Cardinal RADIUS 5GHz SSIDs';
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='For Cardinal RADIUS 5GHz SSIDs';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -226,7 +225,7 @@ CREATE TABLE `ssids_5ghz_radius_deployed` (
   KEY `ssid_id` (`ssid_id`),
   CONSTRAINT `ssids_5ghz_radius_deployed_ibfk_1` FOREIGN KEY (`ssid_id`) REFERENCES `ssids_5ghz_radius` (`ap_ssid_id`),
   CONSTRAINT `ssids_5ghz_radius_deployed_ibfk_2` FOREIGN KEY (`ap_id`) REFERENCES `access_points` (`ap_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=18 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -254,4 +253,4 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-01-26 19:29:01
+-- Dump completed on 2020-01-29 22:03:19

--- a/webapp/cardinal/static/css/metro.css
+++ b/webapp/cardinal/static/css/metro.css
@@ -32,6 +32,10 @@ clear: both;
   background: rgb(99,102,180);
 }
 
+.apmodel {
+  background: rgb(64,179,63);
+}
+
 .metroblock {
   width: 21em;
   padding: 0em 1em 1em 1em;

--- a/webapp/cardinal/system/cardinal_fetch.py
+++ b/webapp/cardinal/system/cardinal_fetch.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+''' Cardinal - An Open Source Cisco Wireless Access Point Controller
+
+MIT License
+
+Copyright © 2019 Cardinal Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+'''
+
+import os
+import schedule
+import scout_info
+import time
+from configparser import ConfigParser
+from cardinal_sys import cardinalSql
+from cardinal_sys import cipherSuite
+from cardinal_sys import MySQLdb
+
+# FETCHER CONFIG
+
+cardinalConfigFile = os.environ['CARDINALCONFIG']
+cardinalConfig = ConfigParser()
+cardinalConfig.read("{}".format(cardinalConfigFile))
+fetcherInterval = cardinalConfig.get('cardinal', 'fetchinterval')
+
+def fetcher():
+    """Uses the scout_info library to fetch access point information and populate the DB."""
+    startTime = time.time()
+    conn = cardinalSql()
+    apIdCursor = conn.cursor()
+    apIdCursor.execute("SELECT ap_id FROM access_points WHERE ap_all_id = '2'")
+    apIdsSql = apIdCursor.fetchall()
+    apIdCursor.close()
+    apIds = []
+    for value in apIdsSql:
+        apIds.append(value[0])
+    for apId in apIds:
+        apInfoCursor = conn.cursor()
+        apInfoCursor.execute("SELECT ap_ip,ap_ssh_username,ap_ssh_password FROM access_points WHERE ap_id = '{}'".format(apId))
+        apInfo = apInfoCursor.fetchall()
+        apInfoCursor.close()
+        for info in apInfo:
+            apIp = info[0]
+            apSshUsername = info[1]
+            encryptedSshPassword = bytes(info[2], 'utf-8')
+            apSshPassword = cipherSuite.decrypt(encryptedSshPassword).decode('utf-8')
+        # Use a try..except to fetch access point information
+        try:
+            apBandwidth = scout_info.scoutGetSpeed(ip=apIp, username=apSshUsername, password=apSshPassword)
+            apMacAddr = scout_info.scoutGetMac(ip=apIp, username=apSshUsername, password=apSshPassword)
+            apModel = scout_info.scoutGetModel(ip=apIp, username=apSshUsername, password=apSshPassword)
+            apSerial = scout_info.scoutGetSerial(ip=apIp, username=apSshUsername, password=apSshPassword)
+            apLocation = scout_info.scoutGetLocation(ip=apIp, username=apSshUsername, password=apSshPassword)
+            apIosInfo = scout_info.scoutGetIosInfo(ip=apIp, username=apSshUsername, password=apSshPassword)
+            apUptime = scout_info.scoutGetUptime(ip=apIp, username=apSshUsername, password=apSshPassword)
+            inputSqlCursor = conn.cursor()
+            inputSqlCursor.execute("UPDATE access_points SET ap_bandwidth = '{0}' WHERE ap_id = '{1}'".format(apBandwidth,apId))
+            inputSqlCursor.execute("UPDATE access_points SET ap_mac_addr = '{0}' WHERE ap_id = '{1}'".format(apMacAddr,apId))
+            inputSqlCursor.execute("UPDATE access_points SET ap_model = '{0}' WHERE ap_id = '{1}'".format(apModel,apId))
+            inputSqlCursor.execute("UPDATE access_points SET ap_serial = '{0}' WHERE ap_id = '{1}'".format(apSerial,apId))
+            inputSqlCursor.execute("UPDATE access_points SET ap_location = '{0}' WHERE ap_id = '{1}'".format(apLocation,apId))
+            inputSqlCursor.execute("UPDATE access_points SET ap_ios_info = '{0}' WHERE ap_id = '{1}'".format(apIosInfo,apId))
+            inputSqlCursor.execute("UPDATE access_points SET ap_uptime = '{0}' WHERE ap_id = '{1}'".format(apUptime,apId))
+            inputSqlCursor.close()
+            conn.commit()
+        except MySQLdb.Error as e:
+            print("ERROR: {}".format(e))
+    completionTime = "INFO: cardinal_fetch completed in:", time.time() - startTime
+    conn.close()
+    return completionTime
+
+# RUN fetch() ON INTERVAL
+
+schedule.every(int('{}'.format(fetcherInterval))).minutes.do(fetcher)
+
+while True:
+    schedule.run_pending()

--- a/webapp/cardinal/system/cardinal_sys.py
+++ b/webapp/cardinal/system/cardinal_sys.py
@@ -37,7 +37,6 @@ from cryptography.fernet import Fernet
 cardinalConfigFile = os.environ['CARDINALCONFIG']
 cardinalConfig = ConfigParser()
 cardinalConfig.read("{}".format(cardinalConfigFile))
-cardinalLogFile = cardinalConfig.get('cardinal', 'logfile')
 flaskKey = cardinalConfig.get('cardinal', 'flaskkey')
 encryptKey = cardinalConfig.get('cardinal', 'encryptkey')
 bytesKey = bytes(encryptKey, 'utf-8')

--- a/webapp/cardinal/templates/add-ap-group.html
+++ b/webapp/cardinal/templates/add-ap-group.html
@@ -3,7 +3,8 @@
 <font face="Verdana">
 <label>Access Point Group Name:</label>
 <input type="text" name="ap_group_name" required>
-<br> 
+<br>
+<br>
 <input type="submit" value="Register">
 </form>
 <br>

--- a/webapp/cardinal/templates/add-ap.html
+++ b/webapp/cardinal/templates/add-ap.html
@@ -28,6 +28,8 @@
 <input type="password" name="ssh_password" required>
 <label>SNMP Community:</label>
 <input type="password" name="ap_snmp" required>
+<br>
+<br>
 <input type="submit" value="Register">
 </form>
 <br>

--- a/webapp/cardinal/templates/ap-model.html
+++ b/webapp/cardinal/templates/ap-model.html
@@ -1,0 +1,9 @@
+<html>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/metro.css') }}">
+
+<div class="metroblock apmodel left">
+  <h3>{{ session['apModel'] }}</h3>
+  <div class="clear"></div>
+  <h2>Model</h2>
+</div>
+</html>

--- a/webapp/cardinal/templates/manage-ap-dashboard.html
+++ b/webapp/cardinal/templates/manage-ap-dashboard.html
@@ -34,6 +34,7 @@
 						<iframe height="310px" scrolling="no" src="/total-ap-clients" style="border:none;" width="300px"></iframe>
 						<iframe height="310px" scrolling="no" src="/total-ap-bandwidth" style="border:none;" width="300px"></iframe>
 						<iframe height="310px" scrolling="no" src="/ap-ip-address" style="border:none;" width="300px"></iframe>
+						<iframe height="310px" scrolling="no" src="/ap-model" style="border:none;" width="300px"></iframe>
 						</div>
 					</div>
 

--- a/webapp/cardinal/views/cardinal_ap_group.py
+++ b/webapp/cardinal/views/cardinal_ap_group.py
@@ -27,6 +27,7 @@ SOFTWARE.
 '''
 
 from cardinal.system.cardinal_sys import cardinalSql
+from cardinal.system.cardinal_sys import MySQLdb
 from flask import Blueprint
 from flask import render_template
 from flask import request
@@ -50,10 +51,14 @@ def doAddApGroup():
         apGroupName = request.form["ap_group_name"]
         status = "{} was successfully registered!".format(apGroupName)
         conn = cardinalSql()
-        addApGroupCursor = conn.cursor()
-        addApGroupCursor.execute("INSERT INTO access_point_groups (ap_group_name) VALUES ('{}')".format(apGroupName))
-        addApGroupCursor.close()
-        conn.commit()
+        try:
+            addApGroupCursor = conn.cursor()
+            addApGroupCursor.execute("INSERT INTO access_point_groups (ap_group_name) VALUES ('{}')".format(apGroupName))
+            addApGroupCursor.close()
+        except MySQLdb.Error as e:
+            return redirect(url_for('cardinal_ap_group_bp.addApGroup', status=e))
+        else:
+            conn.commit()
         conn.close()
         return render_template('add-ap-group.html', status=status)
 

--- a/webapp/cardinal/views/cardinal_auth.py
+++ b/webapp/cardinal/views/cardinal_auth.py
@@ -86,4 +86,5 @@ def logout():
    session.pop('apIp', None)
    session.pop('apTotalClients', None)
    session.pop('apBandwidth', None)
+   session.pop('apModel', None)
    return redirect(url_for('cardinal_auth_bp.index'))

--- a/webapp/cardinal/views/cardinal_ssid.py
+++ b/webapp/cardinal/views/cardinal_ssid.py
@@ -242,7 +242,7 @@ def doDeleteSsid5Ghz():
             deleteSsidCursor = conn.cursor()
             deleteSsidCursor.execute("DELETE FROM ssids_5ghz WHERE ap_ssid_id = '{}'".format(ssidId))
             deleteSsidCursor.close()
-        except cardinalSql.MySQLdb.Error as e:
+        except MySQLdb.Error as e:
             status = e
         finally:
             conn.commit()
@@ -277,7 +277,7 @@ def doDeleteSsid24GhzRadius():
             deleteSsidCursor = conn.cursor()
             deleteSsidCursor.execute("DELETE FROM ssids_24ghz_radius WHERE ap_ssid_id = '{}'".format(ssidId))
             deleteSsidCursor.close()
-        except cardinalSql.MySQLdb.Error as e:
+        except MySQLdb.Error as e:
             status = e
         finally:
             conn.commit()
@@ -312,7 +312,7 @@ def doDeleteSsid5GhzRadius():
             deleteSsidCursor = conn.cursor()
             deleteSsidCursor.execute("DELETE FROM ssids_5ghz_radius WHERE ap_ssid_id = '{}'".format(ssidId))
             deleteSsidCursor.close()
-        except cardinalSql.MySQLdb.Error as e:
+        except MySQLdb.Error as e:
             status = e
         finally:
             conn.commit()

--- a/webapp/cardinal/views/cardinal_visuals.py
+++ b/webapp/cardinal/views/cardinal_visuals.py
@@ -50,6 +50,11 @@ def apIpAddress():
     if session.get("username") is not None:
         return render_template("ap-ip-address.html")
 
+@cardinal_visuals.route("/ap-model", methods=["GET"])
+def apModel():
+    if session.get("username") is not None:
+        return render_template("ap-model.html")
+
 @cardinal_visuals.route("/total-aps", methods=["GET"])
 def totalAps():
     if session.get("username") is not None:


### PR DESCRIPTION
In order for cardinal_fetch.py to commit AP info correctly to MySQL,
the functions need to return a value.

Added cardinal_fetch.py, which is the very in-development crawler
for Cardinal APs. Added the new "fetchinterval" value for cardinal.ini.sample.

Added schedule dependency in requirements.txt.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>