### PR TITLE
webapp/docker: simplified docker build process

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -25,81 +25,109 @@
 # SOFTWARE.
 
 
-# This script is designed to configure Cardinal information, such as system variables, system dependencies, etc. 
-# If anything needs improvement, please open a pull request on my GitHub! Thanks!
-
-######################################################################
-# IMPORTANT: Wipe out the OLD configuration before using this script!#
-######################################################################
+# This script is designed to configure Cardinal information, such as system variables, system dependencies, etc.
+# If anything needs improvement, please open a pull request on the cardinal-dev/Cardinal GitHub repo!
 
 # Gather information
-echo "Welcome to the Cardinal Initial Configuration Guide!"
-echo "MySQL Information"
-echo -e ""
-read -p "Hello, welcome to Cardinal! What is the hostname/IP address of the database for Cardinal? " dbIP
-echo -e ""
-read -p "Ok, I got it. How about an username for the database? " dbUsername
-echo -e ""
-read -p "Great! How about a password for the database? " dbPassword
-echo -e ""
-read -p "Okay, now we need a name for the database. What is the database name? " dbName
-echo -e ""
-read -p "Okay, now we need to add a Cardinal Admin. What is the desired username for Cardinal? " cardinalUser
-echo -e ""
-read -p "Okay, now what is the Cardinal Admin's password? " cardinalPass
-echo -e ""
-read -p "Where do you want to store your MySQL database information? " dbCredDir
-echo -e ""
-read -p "Where is the location of the scout command directory? " commandDir
-echo -e ""
-read -p "What is the desired Flask key? (i.e. Securing session data) " flaskKey
 
-# Create a system user called cardinal. The cardinal user is the user which will run our processes
-sudo useradd cardinal
+configOption="$1"
 
-# Create a log file for Cardinal UI
-rm -rf /var/log/cardinal
-mkdir -p /var/log/cardinal
-touch /var/log/cardinal/cardinal.log
-chown -R cardinal:cardinal /var/log/cardinal
+installUsage() {
+    echo "install.sh - Install Cardinal Environment"
+    echo "Usage:"
+    echo "    --guided: Setup Cardinal using the guided method."
+    echo "    --run: Setup Cardinal using predefined values on CLI."
+}
 
-# Generate Cardinal venv
-sudo python3 -m venv cardinal
-sudo cardinal/bin/pip install -U pip
-sudo cardinal/bin/pip install -r ../requirements.txt
-sudo cardinal/bin/pip install ../lib/.
+setupCardinal() {
 
-# Create a socket directory for uWSGI
-rm -rf /var/lib/cardinal
-mkdir -p /var/lib/cardinal
-chown -R cardinal:cardinal /var/lib/cardinal
+    # Find where the Cardinal base is
+    cardinalBase=$(dirname "$0")
 
-# Set permissions on the cardinal.ini file
-chown -R cardinal:cardinal $dbCredDir/cardinal.ini
+    # Create a system user called cardinal. The cardinal user is the user which will run our processes
+    sudo useradd cardinal
 
-# Create the MySQL database for Cardinal. We also want to import the SQL structure too!
-mysql -u$dbUsername -p$dbPassword -e "CREATE DATABASE "$dbName""
-mysql -u$dbUsername --password=$dbPassword $dbName < ../sql/cardinal.sql
-mysql -u$dbUsername --password=$dbPassword mysql -e "update user set plugin='mysql_native_password' where User='root'"
-mysql -u$dbUsername --password=$dbPassword mysql -e "update user set authentication_string=password('$dbPassword') where user='root'"
-systemctl restart mysql
+    # Create a log file for Cardinal UI
+    rm -rf /var/log/cardinal
+    mkdir -p /var/log/cardinal
+    touch /var/log/cardinal/cardinal.log
+    chown -R cardinal:cardinal /var/log/cardinal
 
-# Create a Cardinal admin
-hashedPass=$(/opt/Cardinal/bin/cardinal/bin/python -c 'from werkzeug.security import generate_password_hash; print(generate_password_hash("'$cardinalPass'", "sha256"))')
-mysql -u$dbUsername -p$dbPassword $dbName -e "INSERT INTO users (username,password) VALUES ('$cardinalUser','$hashedPass')"
+    # Generate Cardinal venv
+    sudo python3 -m venv $cardinalBase/cardinal
+    sudo $cardinalBase/cardinal/bin/pip install -U pip
+    sudo $cardinalBase/cardinal/bin/pip install -r $cardinalBase/../requirements.txt
+    sudo $cardinalBase/cardinal/bin/pip install $cardinalBase/../lib/.
 
-# Generate encryption key
-encryptKey=$(/opt/Cardinal/bin/cardinal/bin/python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+    # Create a socket directory for uWSGI
+    rm -rf /var/lib/cardinal
+    mkdir -p /var/lib/cardinal
+    chown -R cardinal:cardinal /var/lib/cardinal
 
-# Create a configuration file based on user input
-rm $dbCredDir/cardinal.ini
-touch $dbCredDir/cardinal.ini
-echo "[cardinal]" >> $dbCredDir/cardinal.ini
-echo 'dbserver'=""$dbIP"" >> $dbCredDir/cardinal.ini
-echo 'dbuser'=""$dbUsername"" >> $dbCredDir/cardinal.ini
-echo 'dbpassword'=""$dbPassword"" >> $dbCredDir/cardinal.ini
-echo 'dbname'=""$dbName"" >> $dbCredDir/cardinal.ini
-echo 'commanddir'=""$commandDir"" >> $dbCredDir/cardinal.ini
-echo 'flaskkey'=""$flaskKey"" >> $dbCredDir/cardinal.ini
-echo 'encryptkey'=""$encryptKey"" >> $dbCredDir/cardinal.ini
-echo 'commanddebug=off' >> $dbCredDir/cardinal.ini
+    # Set permissions on the cardinal.ini file
+    chown -R cardinal:cardinal $dbCredDir/cardinal.ini
+
+    # Create the MySQL database for Cardinal. We also want to import the SQL structure too!
+    mysql -u$dbUsername -p$dbPassword -e "CREATE DATABASE "$dbName""
+    mysql -u$dbUsername --password=$dbPassword $dbName < $cardinalBase/../sql/cardinal.sql
+    mysql -u$dbUsername --password=$dbPassword mysql -e "update user set plugin='mysql_native_password' where User='root'"
+    mysql -u$dbUsername --password=$dbPassword mysql -e "update user set authentication_string=password('$dbPassword') where user='root'"
+    systemctl restart mysql
+
+    # Create a Cardinal admin
+    hashedPass=$($cardinalBase/cardinal/bin/python -c 'from werkzeug.security import generate_password_hash; print(generate_password_hash("'$cardinalPass'", "sha256"))')
+    mysql -u$dbUsername -p$dbPassword $dbName -e "INSERT INTO users (username,password) VALUES ('$cardinalUser','$hashedPass')"
+
+    # Generate encryption key
+    encryptKey=$($cardinalBase/cardinal/bin/python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+
+    # Create a configuration file based on user input
+    rm $dbCredDir/cardinal.ini
+    touch $dbCredDir/cardinal.ini
+    echo "[cardinal]" >> $dbCredDir/cardinal.ini
+    echo 'dbserver'=""$dbIP"" >> $dbCredDir/cardinal.ini
+    echo 'dbuser'=""$dbUsername"" >> $dbCredDir/cardinal.ini
+    echo 'dbpassword'=""$dbPassword"" >> $dbCredDir/cardinal.ini
+    echo 'dbname'=""$dbName"" >> $dbCredDir/cardinal.ini
+    echo 'commanddir'=""$commandDir"" >> $dbCredDir/cardinal.ini
+    echo 'flaskkey'=""$flaskKey"" >> $dbCredDir/cardinal.ini
+    echo 'encryptkey'=""$encryptKey"" >> $dbCredDir/cardinal.ini
+    echo 'commanddebug=off' >> $dbCredDir/cardinal.ini
+}
+
+if [ "$configOption" = "--guided" ]; then
+    echo "Welcome to the Cardinal Initial Configuration Guide!"
+    echo -e ""
+    read -p "Hello, welcome to Cardinal! What is the hostname/IP address of the database for Cardinal? " dbIP
+    echo -e ""
+    read -p "Ok, I got it. How about an username for the database? " dbUsername
+    echo -e ""
+    read -p "Great! How about a password for the database? " dbPassword
+    echo -e ""
+    read -p "Okay, now we need a name for the database. What is the database name? " dbName
+    echo -e ""
+    read -p "Okay, now we need to add a Cardinal Admin. What is the desired username for Cardinal? " cardinalUser
+    echo -e ""
+    read -p "Okay, now what is the Cardinal Admin's password? " cardinalPass
+    echo -e ""
+    read -p "Where do you want to store your MySQL database information? " dbCredDir
+    echo -e ""
+    read -p "Where is the location of the scout command directory? " commandDir
+    echo -e ""
+    read -p "What is the desired Flask key? (i.e. Securing session data) " flaskKey
+    setupCardinal
+elif [ "$configOption" = "--run" ]; then
+    dbIP="$2"
+    dbUsername="$3"
+    dbPassword="$4"
+    dbName="$5"
+    cardinalUser="$6"
+    cardinalPass="$7"
+    dbCredDir="$8"
+    commandDir="$9"
+    flaskKey="${10}"
+    setupCardinal
+else
+    installUsage
+    echo "ERROR: Please specify a valid option for install.sh"
+fi

--- a/webapp/docker/Dockerfile
+++ b/webapp/docker/Dockerfile
@@ -25,5 +25,8 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV CARDINALCONFIG=/home/cardinal.ini
 
+# Run install.sh
+RUN chmod +x /opt/Cardinal/bin/install.sh
+
 # Finish it!
 CMD ["/lib/systemd/systemd"]

--- a/webapp/docker/build-container.sh
+++ b/webapp/docker/build-container.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Cardinal - An Open Source Cisco Wireless Access Point Controller
+
+# MIT License
+
+# Copyright © 2019 Cardinal Contributors
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# The purpose of this script is to start a standalone (development) container of Cardinal. 
+# If you want to customize more of the build process, please reference the resources within webapp/docker.
+
+# Build Cardinal container
+
+echo "INFO: Starting initial docker build..."
+docker build -t cardinal_build .
+dockerBuildStatus=$(echo $?)
+
+# Start Cardinal container process
+
+if [ "$dockerBuildStatus" = 0 ]; then
+    echo "INFO: Starting Cardinal container based on cardinal_build image..."
+    docker run -d --privileged --name cardinal_build -v /sys/fs/cgroup:/sys/fs/cgroup:ro cardinal_build
+    dockerRunStatus=$(echo $?)
+else
+    echo "ERROR: docker build failed. Please check the docker build stdout/stderr for more information."
+    exit 1
+fi
+
+if [ "$dockerRunStatus" = 0 ]; then
+    echo "INFO: Executing install.sh on Cardinal container..."
+    docker exec -it cardinal_build /bin/bash /opt/Cardinal/bin/install.sh --run 127.0.0.1 root testing1234 cardinal admin admin /home /opt/Cardinal/lib/scout/templates 704cc365c40c8b2ebebe
+    runInstallStatus=$(echo $?)
+else
+    echo "ERROR: Cardinal container could not be made. Please check stdout/stderr for more information."
+    exit 1
+fi
+
+if [ "$runInstallStatus" = 0 ]; then
+    echo "INFO: Running docker commit on Cardinal container..."
+    imageCommit=$(docker commit cardinal_build)
+    dockerCommitStatus=$(echo $?)
+else
+    echo "ERROR: install.sh failed. Please check stdout/stderr for more information."
+    exit 1
+fi
+
+if [ "$dockerCommitStatus" = 0 ]; then
+    echo "INFO: Removing old cardinal artifacts..."
+    dockerImage=$(echo "$imageCommit" | tr -d ":" | sed -e 's/sha256//g' | cut -c 1-12)
+    docker tag "$dockerImage" cardinal
+    docker rm -f cardinal_build
+    docker rmi cardinal_build
+    docker run -d -p 1000:80 --privileged --name cardinal -v /sys/fs/cgroup:/sys/fs/cgroup:ro cardinal
+    echo "INFO: Starting Cardinal..."
+    docker exec -it cardinal systemctl restart cardinal
+else
+    echo "ERROR: docker commit failed. Please check stdout/stderr for more information."
+    exit 1
+fi


### PR DESCRIPTION
I made the Docker build process much more efficient. All you
have to do now is run build-container.sh on a machine with
Docker installed. Doing this will generate a development
instance of Cardinal.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>