### PR TITLE
lib/scout/templates: fixed scout_disable_ap_snmp command set

### DIFF
--- a/lib/scout/templates/scout_disable_ap_snmp
+++ b/lib/scout/templates/scout_disable_ap_snmp
@@ -1,6 +1,4 @@
 enable
 {{ password }}
-no snmp-server community {{ snmp }} RW
-no snmp-server location {{ location }}
-no snmp-server system-shutdown
-do wr
+conf t
+no snmp-server


### PR DESCRIPTION
Running the disable SNMP command set wasn't really disabling
SNMP. If an user wants to re-enable SNMP, they can go into
Cardinal and re-enable SNMP (which will re-push & re-enable
the SNMP config).

Fixes: https://github.com/cardinal-dev/Cardinal/issues/102

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>