### PR TITLE
webapp/cardinal: added session timeout knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 <h1>Cardinal</h1>
 
-Cardinal is an open source Cisco access point controller. Cardinal is built on Python and uses `paramiko` to handle the configuration of access points via SSH. In order to use Cardinal, your Cisco AP's must be in autonomous mode (K9W7 IOS) and have SSH enabled. 
+Cardinal is an open source Cisco access point controller. Cardinal is built on Python and uses `paramiko` to handle the configuration of access points via SSH. In order to use Cardinal, your Cisco AP's must be in autonomous mode (K9W7 IOS) and have SSH enabled.
 
 <h2>Why Cardinal?</h2>
-Cardinals are majestic birds. People say that Cardinals represent loved ones who have passed. When Cardinals visit you, they carry love and remembrance. When I developed Cardinal, I thought of one person, in particular, who loved the red bird. I once knew a woman in a nursing home who loved Cardinals. This woman was exceptionally benevolent and a beautiful soul. Her humor and smile lit up the room every time I would visit. Even though I didn’t know her for a long time, knowing her for the length I did was an honor. Unfortunately, she passed away in 2013.
-In her memory, I decided to name my project after her. Because she loved Cardinals so much, I thought it would be fitting to name my open source Cisco access point controller, Cardinal. I intend to post more about my road to developing Cardinal. Cardinal is still in-development, to this day. Cardinal definitely needs work! As I build Cardinal, I learn more about programming and application development. I hope that one day Cardinal becomes an open source alternative to the Cisco WLC.<br>
+People say that Cardinals represent loved ones who have passed. When Cardinals visit you, they carry love and remembrance. When I developed Cardinal, I thought of one person, in particular, who loved the red bird. I once knew a woman in a nursing home who loved Cardinals. She was exceptionally benevolent and always happy. Unfortunately, she passed away in 2013.
+In her memory, I decided to name the project Cardinal. I intend to post more about my road to developing Cardinal. Cardinal is still in-development to this day. Cardinal definitely needs work! As I build Cardinal, I learn more about programming and application development. I hope that one day Cardinal becomes an open source alternative to the Cisco WLC.<br>
 <br>

--- a/conf/cardinal.ini.sample
+++ b/conf/cardinal.ini.sample
@@ -8,3 +8,4 @@ flaskkey=d67ff999decd7439c230f519ea9fb999
 encryptkey=rFLoNiCTwoOa6o8QOXBy-9WK2-IdSTT8HKiiIzQFHVVZ=
 commanddebug=off
 workers=2
+sessionTimeout=2

--- a/webapp/cardinal/__init__.py
+++ b/webapp/cardinal/__init__.py
@@ -36,10 +36,12 @@ from cardinal.views import cardinal_network_toolkit
 from cardinal.views import cardinal_ssid
 from cardinal.views import cardinal_ssid_ops
 from cardinal.views import cardinal_visuals
+from datetime import timedelta
 from flask import Flask
 
 Cardinal = Flask(__name__)
 Cardinal.secret_key = "{}".format(cardinal_sys.flaskKey)
+Cardinal.permanent_session_lifetime = timedelta(minutes=int(cardinal_sys.sessionTimeout))
 
 Cardinal.register_blueprint(cardinal_ap_group.cardinal_ap_group)
 Cardinal.register_blueprint(cardinal_ap_ops.cardinal_ap_ops)

--- a/webapp/cardinal/system/cardinal_fetch.py
+++ b/webapp/cardinal/system/cardinal_fetch.py
@@ -33,6 +33,7 @@ from cardinal.system.cardinal_sys import cardinalSql
 from cardinal.system.cardinal_sys import cipherSuite
 from datetime import datetime
 from scout import scout_info
+
 timeStamp = datetime.now()
 
 def gatherApInfo(apId):

--- a/webapp/cardinal/system/cardinal_sys.py
+++ b/webapp/cardinal/system/cardinal_sys.py
@@ -43,6 +43,7 @@ flaskKey = cardinalConfig.get('cardinal', 'flaskkey')
 encryptKey = cardinalConfig.get('cardinal', 'encryptkey')
 bytesKey = bytes(encryptKey, 'utf-8')
 cipherSuite = Fernet(bytesKey)
+sessionTimeout = cardinalConfig.get('cardinal', 'sessionTimeout')
 
 # MySQL AUTHENTICATION & HANDLING
 


### PR DESCRIPTION
Leverages the PERMANENT_SESSION_LIFETIME (Flask) config value
to set explicit timeout (when inactivity exceeds integer for minutes).

Fixes: https://github.com/cardinal-dev/Cardinal/issues/127

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>