### PR TITLE
ci: fixed paths in ci/cardinal.ini

### DIFF
--- a/ci/cardinal.ini
+++ b/ci/cardinal.ini
@@ -3,13 +3,11 @@ dbserver=mariadb
 dbuser=root
 dbpassword=test1234
 dbname=cardinal
-commanddir=/opt/Cardinal/lib/scout/templates
 flaskkey=d67ff999decd7439c230f519ea9fb999
 encryptkey=W-kYJoioEnIscpjhwraQlE54XkqxeNUByt-3A-az_xU=
-commanddebug=off
 workers=2
 sessionTimeout=10000
 
 [scout]
-commandDir=/opt/Cardinal/bin/cardinal/lib/python3.8/site-packages/scout/templates
+commandDir=/opt/venv/cardinal/lib/python3.8/site-packages/scout/templates
 commandDebug=on

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,19 +1,18 @@
 #!/bin/sh
 
-# Prevent race condition with MariaDB
-sleep 10
-
-# Initialize MariaDB
+# Generate password hash for admin user
 hashedPass=$(/opt/venv/cardinal/bin/python -c 'from werkzeug.security import generate_password_hash; print(generate_password_hash("'$CARDINAL_PASSWORD'", "sha256"))')
 
 # Test MariaDB connectivity
-for i in {1..10}; do sleep 1;
-    if nc -vz mariadb 3306; then
-        mysql -h mariadb -u"$CARDINAL_SQL_USERNAME" -p"$CARDINAL_SQL_PASSWORD" cardinal -e "INSERT INTO users (username,password) VALUES ('$CARDINAL_USERNAME','$hashedPass')"
-    else
-        continue
-    fi
-done
+for i in `seq 1 10`;
+    do sleep 1;
+        if nc -vz mariadb 3306; then
+            mysql -h mariadb -u"$CARDINAL_SQL_USERNAME" -p"$CARDINAL_SQL_PASSWORD" cardinal -e "INSERT INTO users (username,password) VALUES ('$CARDINAL_USERNAME','$hashedPass')"
+        else
+            echo "Retrying MariaDB connection..."
+            continue
+        fi
+    done
 
 # Initiate NGINX for uWSGI
 /usr/sbin/nginx -c /etc/nginx/nginx.conf


### PR DESCRIPTION
corrected Bourne Shell compatibility by using seq.
implemented retry mechanism for MariaDB connectivity (default to 10)